### PR TITLE
Fixed Dialog isOpen

### DIFF
--- a/packages/dialog/Dialog.svelte
+++ b/packages/dialog/Dialog.svelte
@@ -56,7 +56,7 @@
   }
 
   export function isOpen(...args) {
-    return dialog.isOpen(...args);
+    return dialog.isOpen;
   }
 
   export function layout(...args) {


### PR DESCRIPTION
The MDC dialog component doesn't have a method named "isOpen()", it's actually a property.