### PR TITLE
Handle undefined number input for textfield

### DIFF
--- a/packages/textfield/Input.svelte
+++ b/packages/textfield/Input.svelte
@@ -36,7 +36,7 @@
   $: if (type === 'file') {
     delete valueProp.value;
   } else {
-    valueProp.value = value || '';
+    valueProp.value = value === undefined ? '' : value;
   }
 
   onMount(() => {

--- a/packages/textfield/Input.svelte
+++ b/packages/textfield/Input.svelte
@@ -32,11 +32,14 @@
 
   let element;
   let valueProp = {};
+  let rawValue = '' + value;
+  // Keep separate rawValue because MDCTextField expects to work with strings,
+  // but we parse numbers and ranges for ease of use.
 
   $: if (type === 'file') {
     delete valueProp.value;
   } else {
-    valueProp.value = value;
+    valueProp.value = rawValue;
   }
 
   onMount(() => {
@@ -50,16 +53,17 @@
   }
 
   function valueUpdater(e) {
+    rawValue = e.target.value;
     switch (type) {
       case 'number':
       case 'range':
-        value = toNumber(e.target.value);
+        value = toNumber(rawValue);
         break;
       case 'file':
         files = e.target.files;
         // Fall through.
       default:
-        value = e.target.value;
+        value = rawValue;
         break;
     }
   }

--- a/packages/textfield/Input.svelte
+++ b/packages/textfield/Input.svelte
@@ -32,14 +32,11 @@
 
   let element;
   let valueProp = {};
-  let rawValue = '' + value;
-  // Keep separate rawValue because MDCTextField expects to work with strings,
-  // but we parse numbers and ranges for ease of use.
 
   $: if (type === 'file') {
     delete valueProp.value;
   } else {
-    valueProp.value = rawValue;
+    valueProp.value = value || '';
   }
 
   onMount(() => {
@@ -53,17 +50,16 @@
   }
 
   function valueUpdater(e) {
-    rawValue = e.target.value;
     switch (type) {
       case 'number':
       case 'range':
-        value = toNumber(rawValue);
+        value = toNumber(e.target.value);
         break;
       case 'file':
         files = e.target.files;
         // Fall through.
       default:
-        value = rawValue;
+        value = e.target.value;
         break;
     }
   }


### PR DESCRIPTION
Fix for #40 
Solve the issue by maintaining setting `valueProps.value` to `''` when `value` is `undefined`, so MDCTextField can interact with it properly.