### PR TITLE
fix sapper compiler warning

### DIFF
--- a/packages/common/ClassAdder.svelte
+++ b/packages/common/ClassAdder.svelte
@@ -6,7 +6,7 @@
 ><slot></slot></svelte:component>
 
 <script context="module">
-  export let internals = {
+  export const internals = {
     component: null,
     smuiClass: null,
     contexts: {}


### PR DESCRIPTION
When you try to `npm run dev` on an [webpack based sapper installation](https://github.com/manuel3108/sapper-smui-template) and add for example the drawer component, you will get the following **warning**:
```js
node_modules/@smui/common/ClassAdder.svelte
Module Warning (from ./node_modules/svelte-loader/index.js):
ClassAdder has unused export property 'internals'. If it is for external reference only, please consider using `export const 'internals'` (9:13)
 7: 
 8: <script context="module">
 9:   export let internals = {
                 ^
10:     component: null,
11:     smuiClass: null,
```

This occurs at least for the drawer and the data-tables component, but propably for every component who uses `ClassAdder.svelte`. This will be fixed width this PR