### PR TITLE
fix: Cannot read property 'destroy' of undefined in menuSurface

### DIFF
--- a/packages/menu-surface/MenuSurface.svelte
+++ b/packages/menu-surface/MenuSurface.svelte
@@ -101,9 +101,9 @@
     let isHoisted = false;
     if (menuSurface) {
       isHoisted = menuSurface.foundation_.isHoistedElement_;
-    }
-    if (instantiate !== false) {
-      menuSurface.destroy();
+      if (instantiate !== false) {
+        menuSurface.destroy();
+      }
     }
     if (isHoisted) {
       element.parentNode.removeChild(element);


### PR DESCRIPTION
This was a regression in beta18. Svelte calls onDestroy on the server, so we have to check that menuSurface is not undefined before calling destroy()