### PR TITLE
fix: undefined current_component in browsers not supporting import #60

### DIFF
--- a/packages/button/Button.svelte
+++ b/packages/button/Button.svelte
@@ -24,7 +24,7 @@
 
 <script>
   import {setContext, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
@@ -32,7 +32,7 @@
   import Button from '@smui/common/Button.svelte';
   import Ripple from '@smui/ripple/bare.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/button/Group.svelte
+++ b/packages/button/Group.svelte
@@ -11,12 +11,12 @@
 
 <script>
   import {setContext, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/card/Actions.svelte
+++ b/packages/card/Actions.svelte
@@ -11,12 +11,12 @@
 
 <script>
   import {setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/card/Card.svelte
+++ b/packages/card/Card.svelte
@@ -11,12 +11,12 @@
 ><slot></slot></div>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/card/Media.svelte
+++ b/packages/card/Media.svelte
@@ -11,12 +11,12 @@
 ><slot></slot></div>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/card/PrimaryAction.svelte
+++ b/packages/card/PrimaryAction.svelte
@@ -12,13 +12,13 @@
 ><slot></slot></div>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
   import Ripple from '@smui/ripple/bare.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/checkbox/Checkbox.svelte
+++ b/packages/checkbox/Checkbox.svelte
@@ -35,13 +35,13 @@
 <script>
   import {MDCCheckbox} from '@material/checkbox';
   import {onMount, onDestroy, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
   let uninitializedValue = () => {};
 
   export let use = [];

--- a/packages/chips/Chip.svelte
+++ b/packages/chips/Chip.svelte
@@ -14,12 +14,12 @@
 <script>
   import {MDCChip} from '@material/chips';
   import {onMount, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCChip:interaction', 'MDCChip:selection', 'MDCChip:removal', 'MDCChip:trailingIconInteraction']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCChip:interaction', 'MDCChip:selection', 'MDCChip:removal', 'MDCChip:trailingIconInteraction']);
 
   export let use = [];
   let className = '';

--- a/packages/chips/Set.svelte
+++ b/packages/chips/Set.svelte
@@ -21,12 +21,12 @@
 <script>
   import {MDCChipSet} from '@material/chips';
   import {onMount, onDestroy, afterUpdate} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/common/A.svelte
+++ b/packages/common/A.svelte
@@ -6,12 +6,12 @@
 ><slot></slot></a>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   export let href = 'javascript:void(0);';

--- a/packages/common/Aside.svelte
+++ b/packages/common/Aside.svelte
@@ -6,12 +6,12 @@
 ><slot></slot></aside>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/Button.svelte
+++ b/packages/common/Button.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></button>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/ClassAdder.svelte
+++ b/packages/common/ClassAdder.svelte
@@ -15,7 +15,7 @@
 
 <script>
   import {setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
@@ -30,7 +30,7 @@
   const smuiClass = internals.class;
   const contexts = internals.contexts;
 
-  const forwardEvents = forwardEventsBuilder(current_component, smuiForwardEvents);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), smuiForwardEvents);
 
   for (let context in contexts) {
     if (contexts.hasOwnProperty(context)) {

--- a/packages/common/Div.svelte
+++ b/packages/common/Div.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></div>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/Footer.svelte
+++ b/packages/common/Footer.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></footer>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/H1.svelte
+++ b/packages/common/H1.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></h1>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/H2.svelte
+++ b/packages/common/H2.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></h2>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/H3.svelte
+++ b/packages/common/H3.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></h3>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/H4.svelte
+++ b/packages/common/H4.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></h4>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/H5.svelte
+++ b/packages/common/H5.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></h5>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/H6.svelte
+++ b/packages/common/H6.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></h6>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/Header.svelte
+++ b/packages/common/Header.svelte
@@ -6,12 +6,12 @@
 ><slot></slot></header>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/Icon.svelte
+++ b/packages/common/Icon.svelte
@@ -19,12 +19,12 @@
 
 <script>
   import {getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/common/Img.svelte
+++ b/packages/common/Img.svelte
@@ -7,12 +7,12 @@
 />
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   export let alt = '';

--- a/packages/common/Label.svelte
+++ b/packages/common/Label.svelte
@@ -16,12 +16,12 @@
 
 <script>
   import {getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/common/Li.svelte
+++ b/packages/common/Li.svelte
@@ -6,12 +6,12 @@
 ><slot></slot></li>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/Section.svelte
+++ b/packages/common/Section.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></section>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/Span.svelte
+++ b/packages/common/Span.svelte
@@ -5,12 +5,12 @@
 ><slot></slot></span>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/common/Ul.svelte
+++ b/packages/common/Ul.svelte
@@ -6,12 +6,12 @@
 ><slot></slot></ul>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from './forwardEvents.js';
   import {exclude} from './exclude.js';
   import {useActions} from './useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 </script>

--- a/packages/data-table/Body.svelte
+++ b/packages/data-table/Body.svelte
@@ -7,12 +7,12 @@
 
 <script>
   import {setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/data-table/Cell.svelte
+++ b/packages/data-table/Cell.svelte
@@ -29,12 +29,12 @@
 
 <script>
   import {getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   let header = getContext('SMUI:data-table:row:header');
 

--- a/packages/data-table/DataTable.svelte
+++ b/packages/data-table/DataTable.svelte
@@ -21,7 +21,7 @@
   import {MDCDataTable} from '@material/data-table';
   import {events} from '@material/data-table/constants';
   import {onMount, onDestroy, getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
@@ -35,7 +35,7 @@
     throw new Error('MDC API has changed!');
   }
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCDataTable:rowSelectionChanged', 'MDCDataTable:selectedAll', 'MDCDataTable:unselectedAll']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCDataTable:rowSelectionChanged', 'MDCDataTable:selectedAll', 'MDCDataTable:unselectedAll']);
 
   export let use = [];
   let className = '';

--- a/packages/data-table/Head.svelte
+++ b/packages/data-table/Head.svelte
@@ -6,12 +6,12 @@
 
 <script>
   import {setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
 

--- a/packages/data-table/Row.svelte
+++ b/packages/data-table/Row.svelte
@@ -14,12 +14,12 @@
 
 <script>
   import {getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/dialog/Dialog.svelte
+++ b/packages/dialog/Dialog.svelte
@@ -19,12 +19,12 @@
 <script>
   import {MDCDialog} from '@material/dialog';
   import {onMount, onDestroy, getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCDialog:opening', 'MDCDialog:opened', 'MDCDialog:closing', 'MDCDialog:closed']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCDialog:opening', 'MDCDialog:opened', 'MDCDialog:closing', 'MDCDialog:closed']);
 
   export let use = [];
   let className = '';

--- a/packages/drawer/Drawer.svelte
+++ b/packages/drawer/Drawer.svelte
@@ -15,12 +15,12 @@
 <script>
   import {MDCDrawer} from "@material/drawer";
   import {onMount, onDestroy, afterUpdate, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCDrawer:opened', 'MDCDrawer:closed']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCDrawer:opened', 'MDCDrawer:closed']);
 
   export let use = [];
   let className = '';

--- a/packages/fab/Fab.svelte
+++ b/packages/fab/Fab.svelte
@@ -15,13 +15,13 @@
 
 <script>
   import {setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
   import Ripple from '@smui/ripple/bare.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/floating-label/FloatingLabel.svelte
+++ b/packages/floating-label/FloatingLabel.svelte
@@ -20,12 +20,12 @@
 <script>
   import {MDCFloatingLabel} from '@material/floating-label';
   import {onMount, onDestroy, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/form-field/FormField.svelte
+++ b/packages/form-field/FormField.svelte
@@ -24,13 +24,13 @@
 <script>
   import {MDCFormField} from '@material/form-field';
   import {onMount, onDestroy, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/icon-button/IconButton.svelte
+++ b/packages/icon-button/IconButton.svelte
@@ -46,13 +46,13 @@
 <script>
   import {MDCIconButtonToggle} from '@material/icon-button';
   import {onDestroy, getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
   import Ripple from '@smui/ripple/bare.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCIconButtonToggle:change']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCIconButtonToggle:change']);
 
   export let use = [];
   let className = '';

--- a/packages/image-list/ImageList.svelte
+++ b/packages/image-list/ImageList.svelte
@@ -12,12 +12,12 @@
 
 <script>
   import {setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/line-ripple/LineRipple.svelte
+++ b/packages/line-ripple/LineRipple.svelte
@@ -13,12 +13,12 @@
 <script>
   import {MDCLineRipple} from '@material/line-ripple';
   import {onMount, onDestroy} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/linear-progress/LinearProgress.svelte
+++ b/packages/linear-progress/LinearProgress.svelte
@@ -25,12 +25,12 @@
 <script>
   import {MDCLinearProgress} from '@material/linear-progress';
   import {onMount, onDestroy} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/list/Item.svelte
+++ b/packages/list/Item.svelte
@@ -67,14 +67,14 @@
 
 <script>
   import {onMount, onDestroy, getContext, setContext, createEventDispatcher} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
   import Ripple from '@smui/ripple/bare.js';
 
   const dispatch = createEventDispatcher();
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
   let checked = false;
 
   export let use = [];

--- a/packages/list/Label.svelte
+++ b/packages/list/Label.svelte
@@ -8,12 +8,12 @@
 
 <script>
   import {getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/list/List.svelte
+++ b/packages/list/List.svelte
@@ -38,12 +38,12 @@
 <script>
   import {MDCList} from '@material/list';
   import {onMount, onDestroy, getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCList:action']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCList:action']);
 
   export let use = [];
   let className = '';

--- a/packages/list/Separator.svelte
+++ b/packages/list/Separator.svelte
@@ -26,12 +26,12 @@
 {/if}
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/menu-surface/MenuSurface.svelte
+++ b/packages/menu-surface/MenuSurface.svelte
@@ -22,12 +22,12 @@
 <script>
   import {MDCMenuSurface} from '@material/menu-surface';
   import {onMount, onDestroy, getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCMenuSurface:closed', 'MDCMenuSurface:opened']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCMenuSurface:closed', 'MDCMenuSurface:opened']);
 
   export let use = [];
   let className = '';

--- a/packages/menu/Menu.svelte
+++ b/packages/menu/Menu.svelte
@@ -10,13 +10,13 @@
 <script>
   import {MDCMenu} from '@material/menu';
   import {onMount, onDestroy, getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
   import MenuSurface, {Corner, CornerBit} from '@smui/menu-surface/MenuSurface.svelte';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCMenu:selected', 'MDCMenuSurface:closed', 'MDCMenuSurface:opened']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCMenu:selected', 'MDCMenuSurface:closed', 'MDCMenuSurface:opened']);
 
   export let use = [];
   let className = '';

--- a/packages/menu/SelectionGroup.svelte
+++ b/packages/menu/SelectionGroup.svelte
@@ -11,13 +11,13 @@
 </li>
 
 <script>
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   export let list$use = [];

--- a/packages/notched-outline/NotchedOutline.svelte
+++ b/packages/notched-outline/NotchedOutline.svelte
@@ -20,12 +20,12 @@
 <script>
   import {MDCNotchedOutline} from '@material/notched-outline';
   import {onMount, onDestroy} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/paper/Paper.svelte
+++ b/packages/paper/Paper.svelte
@@ -15,12 +15,12 @@
 
 <script>
   import {onMount, onDestroy, afterUpdate, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/radio/Radio.svelte
+++ b/packages/radio/Radio.svelte
@@ -30,13 +30,13 @@
 <script>
   import {MDCRadio} from '@material/radio';
   import {onMount, onDestroy, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
   let uninitializedValue = () => {};
 
   export let use = [];

--- a/packages/select/Option.svelte
+++ b/packages/select/Option.svelte
@@ -17,13 +17,13 @@
 
 <script>
   import {getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
   import Item from '@smui/list/Item.svelte';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   const className = '';

--- a/packages/select/Select.svelte
+++ b/packages/select/Select.svelte
@@ -92,7 +92,7 @@
 <script>
   import {MDCSelect} from '@material/select';
   import {onMount, onDestroy, getContext, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
@@ -103,7 +103,7 @@
   import LineRipple from '@smui/line-ripple/LineRipple.svelte';
   import NotchedOutline from '@smui/notched-outline/NotchedOutline.svelte';
 
-  const forwardEvents = forwardEventsBuilder(current_component, 'MDCSelect:change');
+  const forwardEvents = forwardEventsBuilder(get_current_component(), 'MDCSelect:change');
   const uninitializedValue = () => {};
 
   export let use = [];

--- a/packages/select/helper-text/HelperText.svelte
+++ b/packages/select/helper-text/HelperText.svelte
@@ -15,12 +15,12 @@
 <script>
   import {MDCSelectHelperText} from '@material/select/helper-text';
   import {onMount, onDestroy} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/select/icon/Icon.svelte
+++ b/packages/select/icon/Icon.svelte
@@ -11,12 +11,12 @@
 <script>
   import {MDCSelectIcon} from '@material/select/icon';
   import {onMount, onDestroy} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/slider/Slider.svelte
+++ b/packages/slider/Slider.svelte
@@ -41,12 +41,12 @@
 <script>
   import {MDCSlider} from '@material/slider';
   import {onMount, onDestroy, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCSlider:input', 'MDCSlider:change']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCSlider:input', 'MDCSlider:change']);
 
   export let use = [];
   let className = '';

--- a/packages/snackbar/Snackbar.svelte
+++ b/packages/snackbar/Snackbar.svelte
@@ -25,13 +25,13 @@
 <script>
   import {MDCSnackbar} from '@material/snackbar';
   import {onMount, onDestroy, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCSnackbar:opening', 'MDCSnackbar:opened', 'MDCSnackbar:closing', 'MDCSnackbar:closed']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCSnackbar:opening', 'MDCSnackbar:opened', 'MDCSnackbar:closing', 'MDCSnackbar:closed']);
   const uninitializedValue = () => {};
 
   export let use = [];

--- a/packages/switch/Switch.svelte
+++ b/packages/switch/Switch.svelte
@@ -33,13 +33,13 @@
 <script>
   import {MDCSwitch} from '@material/switch';
   import {onMount, onDestroy, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
   let uninitializedValue = () => {};
 
   export let use = [];

--- a/packages/tab-bar/TabBar.svelte
+++ b/packages/tab-bar/TabBar.svelte
@@ -19,14 +19,14 @@
 <script>
   import {MDCTabBar} from '@material/tab-bar';
   import {onMount, onDestroy, setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
   import TabScroller from '@smui/tab-scroller/TabScroller.svelte';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCTabBar:activated']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCTabBar:activated']);
   let uninitializedValue = () => {};
 
   export let use = [];

--- a/packages/tab-indicator/TabIndicator.svelte
+++ b/packages/tab-indicator/TabIndicator.svelte
@@ -26,13 +26,13 @@
 <script>
   import {MDCTabIndicator} from '@material/tab-indicator';
   import {onMount, onDestroy, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/tab-scroller/TabScroller.svelte
+++ b/packages/tab-scroller/TabScroller.svelte
@@ -21,13 +21,13 @@
 <script>
   import {MDCTabScroller} from '@material/tab-scroller';
   import {onMount, onDestroy, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/tab/Tab.svelte
+++ b/packages/tab/Tab.svelte
@@ -42,14 +42,14 @@
 <script>
   import {MDCTab} from '@material/tab';
   import {onMount, onDestroy, setContext, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
   import TabIndicator from '@smui/tab-indicator/TabIndicator.svelte';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCTab:interacted']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCTab:interacted']);
   let activeEntry = getContext('SMUI:tab:active');
 
   export let use = [];

--- a/packages/textfield/Input.svelte
+++ b/packages/textfield/Input.svelte
@@ -13,12 +13,12 @@
 
 <script>
   import {onMount} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['change', 'input']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['change', 'input']);
 
   export let use = [];
   let className = '';

--- a/packages/textfield/Textarea.svelte
+++ b/packages/textfield/Textarea.svelte
@@ -10,12 +10,12 @@
 
 <script>
   import {onMount} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['change', 'input']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['change', 'input']);
 
   export let use = [];
   let className = '';

--- a/packages/textfield/Textfield.svelte
+++ b/packages/textfield/Textfield.svelte
@@ -90,7 +90,7 @@
 <script>
   import {MDCTextField} from '@material/textfield';
   import {onMount, onDestroy, getContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
@@ -101,7 +101,7 @@
   import Input from './Input.svelte';
   import Textarea from './Textarea.svelte';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
   let uninitializedValue = () => {};
 
   export let use = [];

--- a/packages/textfield/character-counter/CharacterCounter.svelte
+++ b/packages/textfield/character-counter/CharacterCounter.svelte
@@ -9,12 +9,12 @@
 <script>
   import {MDCTextFieldCharacterCounter} from '@material/textfield/character-counter';
   import {onMount, onDestroy} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/textfield/helper-text/HelperText.svelte
+++ b/packages/textfield/helper-text/HelperText.svelte
@@ -22,13 +22,13 @@
 <script>
   import {MDCTextFieldHelperText} from '@material/textfield/helper-text';
   import {onMount, onDestroy} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {prefixFilter} from '@smui/common/prefixFilter.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/textfield/icon/Icon.svelte
+++ b/packages/textfield/icon/Icon.svelte
@@ -11,12 +11,12 @@
 <script>
   import {MDCTextFieldIcon} from '@material/textfield/icon';
   import {onMount, onDestroy} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component);
+  const forwardEvents = forwardEventsBuilder(get_current_component());
 
   export let use = [];
   let className = '';

--- a/packages/top-app-bar/Section.svelte
+++ b/packages/top-app-bar/Section.svelte
@@ -13,12 +13,12 @@
 
 <script>
   import {setContext} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCList:action']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCList:action']);
 
   export let use = [];
   let className = '';

--- a/packages/top-app-bar/TopAppBar.svelte
+++ b/packages/top-app-bar/TopAppBar.svelte
@@ -19,12 +19,12 @@
 <script>
   import {MDCTopAppBar} from '@material/top-app-bar';
   import {onMount, onDestroy} from 'svelte';
-  import {current_component} from 'svelte/internal';
+  import {get_current_component} from 'svelte/internal';
   import {forwardEventsBuilder} from '@smui/common/forwardEvents.js';
   import {exclude} from '@smui/common/exclude.js';
   import {useActions} from '@smui/common/useActions.js';
 
-  const forwardEvents = forwardEventsBuilder(current_component, ['MDCList:action']);
+  const forwardEvents = forwardEventsBuilder(get_current_component(), ['MDCList:action']);
 
   export let use = [];
   let className = '';


### PR DESCRIPTION
Fixes `current_component` being `undefined` when `forwardEventsBuilder()` is called by using `get_current_component()` instead of `current_component` reported on #60. 

Tested on Edge 18.