### PR TITLE
Use anchor instead of button

### DIFF
--- a/packages/tab/Tab.svelte
+++ b/packages/tab/Tab.svelte
@@ -1,4 +1,5 @@
-<button
+<a
+  {href}
   bind:this={element}
   use:useActions={use}
   use:forwardEvents
@@ -10,7 +11,7 @@
   aria-selected={active}
   tabindex="{active ? '0' : '-1'}"
   on:MDCTab:interacted={interactedHandler}
-  {...exclude($$props, ['use', 'class', 'ripple', 'active', 'stacked', 'minWidth', 'indicatorSpanOnlyContent', 'focusOnActivate', 'content$', 'tabIndicator$'])}
+  {...exclude($$props, ['href', 'use', 'class', 'ripple', 'active', 'stacked', 'minWidth', 'indicatorSpanOnlyContent', 'focusOnActivate', 'content$', 'tabIndicator$'])}
 >
   <span
     use:useActions={content$use}
@@ -34,7 +35,7 @@
   {#if ripple}
     <span class="mdc-tab__ripple"></span>
   {/if}
-</button>
+</a>
 
 <script>
   import {MDCTab} from '@material/tab';
@@ -49,6 +50,7 @@
   const forwardEvents = forwardEventsBuilder(current_component, ['MDCTab:interacted']);
   let activeEntry = getContext('SMUI:tab:active');
 
+  export let href = '';
   export let use = [];
   let className = '';
   export {className as class};


### PR DESCRIPTION
`@smui/tab` component is built over a `button` tag. The problem is that tabs can be used to navigate inside the app. With Sapper, navigation is easier using `href` instead of `goto` method, and more over, anchors support `rel="prefetch"` which allows Sapper to prefetch the page as soon as the user hovers the tab. The UX is much better and the app is snappier.

So the goal of this PR is simply replacing then `button` tag by an `anchor`.

Thanks and keep up the good work