### PR TITLE
Fixing PostCSS extract configuration to prevent a Sapper fatal error

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ Here are some features you should know about:
 
     // ...
 
+    // At the client svelte options change emitCss to false and css to true
+    svelte({
+      dev,
+      hydratable: true,
+      emitCss: false,
+      css: true
+    }),
+
     // Find this line, under "plugins:"
     commonjs(),
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Here are some features you should know about:
     // Then paste the following after it.
     // Once in the "client:" section, and again in the "server:" section.
     postcss({
-      extract: true,
+      extract: false,
       minimize: true,
       use: [
         ['sass', {


### PR DESCRIPTION
An update to the README instructions to using svelte-material-ui with Sapper:

As used in the very same site demo, the PostCSS `extract` configuration is set to `false` and with that Sapper with Svelte works like a charm. It also sets `emitCss` to `false` and adds `css` to `true` for the Sapper client section.

Thank  you very much for smui, it’s really really cool.

All the bests for you and your projects, specially Tunnelgram.

NOTE: this is related to error https://github.com/hperrin/svelte-material-ui/issues/172