### PR TITLE
Fixed switchTheme so it doesn't keeps adding links

### DIFF
--- a/THEMING.md
+++ b/THEMING.md
@@ -102,6 +102,7 @@ function switchTheme() {
   if (!themeLink) {
     themeLink = document.createElement('link');
     themeLink.rel = 'stylesheet';
+    themeLink.id = 'theme';
   }
   themeLink.href = `client/smui${lightTheme ? '' : '-dark'}.css`;
   document.head.appendChild(themeLink);


### PR DESCRIPTION
I noticed when implementing the switchTheme method, that it kept adding link elements at the bottom of the head, even though there is a themeLink check. Fixed it by just also setting the id when a new link element must be created to switch the theme.