### PR TITLE
Fixed css selector :globa to :global 

### DIFF
--- a/site/src/routes/demo/tabs/index.svelte
+++ b/site/src/routes/demo/tabs/index.svelte
@@ -56,7 +56,7 @@
 </script>
 
 <style>
-  section > :globa(div) {
+  section > :global(div) {
     margin-bottom: 40px;
   }
 </style>


### PR DESCRIPTION
Fixed the following CSS selector on line 59: 
```css
section > :globa(div) {}
```
to
```css
section > :global(div) {}
```

