### PR TITLE
Fixes #276

### DIFF
--- a/packages/textfield/helper-text/HelperText.svelte
+++ b/packages/textfield/helper-text/HelperText.svelte
@@ -77,7 +77,9 @@
   function hasClass(className) {
     return className in internalClasses
       ? internalClasses[className]
-      : getElement().classList.contains(className);
+      : (getElement() 
+        ? getElement().classList.contains(className) 
+        : false);
   }
 
   function addClass(className) {


### PR DESCRIPTION
Fixes #276 (Texfield throws console errors when used with <svelte:fragment> to switch between two Helpertext components after typing invalid text and exiting the field)