### PR TITLE
fix: "main" (and "svelte") not set in package.json

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Accordion",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Autocomplete",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Badge",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Banner",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Button",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Card",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Checkbox",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/chips/package.json
+++ b/packages/chips/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Chips",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/circular-progress/package.json
+++ b/packages/circular-progress/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Circular Progress",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Data Table",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Dialog",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Drawer",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Floating Action Button",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/floating-label/package.json
+++ b/packages/floating-label/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Floating Label",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/form-field/package.json
+++ b/packages/form-field/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Form Field",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Icon Button",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/image-list/package.json
+++ b/packages/image-list/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Image List",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/layout-grid/package.json
+++ b/packages/layout-grid/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Layout Grid",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/line-ripple/package.json
+++ b/packages/line-ripple/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Line Ripple",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Linear Progress",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - List",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/menu-surface/package.json
+++ b/packages/menu-surface/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Menu Surface",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Menu",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Notched Outline",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Paper",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Radio",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Ripple",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/segmented-button/package.json
+++ b/packages/segmented-button/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Segmented Button",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Slider",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Switch",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Tab Bar",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Tab Indicator",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Tab Scroller",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Tab",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Tooltip",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Top App Bar",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",

--- a/packages/touch-target/package.json
+++ b/packages/touch-target/package.json
@@ -3,7 +3,9 @@
   "version": "6.0.0-beta.7",
   "description": "Svelte Material UI - Touch Target",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "svelte": "dist/index.js",
   "types": "src/index.ts",
   "keywords": [
     "svelte",


### PR DESCRIPTION
As by commit message:

```
This causes an error when using SvelteKit:

  Unknown file extension ".svelte" for /.../node_modules/@smui/button/dist/Button.svelte

Fixes #375.
```

I thought it was a bit sad to find this awesome library, only for it to not work with SvelteKit. So I did a lazy `sed` operation to fix things according to https://github.com/hperrin/svelte-material-ui/issues/375#issuecomment-991839553 .

Note: I know nothing about npm, or what this PR actually does. I kinda blindly applied what the comment said, in the hope you know more about this, and can judge whether this should happen this way or not ;) It does fix the bug if I apply this locally in my `node_modules` folder :)

If you do agree with it, I could really appreciate a new beta soon, as this kinda prevents me using this library with GitHub Pages :)

Either way, while I have the opportunity: tnx a lot for this library!! It made my life a whole lot easier/faster :)