### PR TITLE
fix: setting a new start/end above the current end crashes a slider

### DIFF
--- a/packages/slider/src/Slider.svelte
+++ b/packages/slider/src/Slider.svelte
@@ -334,11 +334,22 @@
     if (previousValue !== value && typeof value === 'number') {
       instance.setValue(value);
     }
-    if (previousStart !== start && typeof start === 'number') {
-      instance.setValueStart(start);
-    }
-    if (previousEnd !== end && typeof end === 'number') {
-      instance.setValue(end);
+    if (previousStart !== start && typeof start === 'number' && previousEnd !== end && typeof end === 'number') {
+      // Prevent setting the start value temporary higher than the current end value.
+      if (start > previousEnd) {
+        instance.setValue(end);
+        instance.setValueStart(start);
+      } else {
+        instance.setValueStart(start);
+        instance.setValue(end);
+      }
+    } else {
+      if (previousStart !== start && typeof start === 'number') {
+        instance.setValueStart(start);
+      }
+      if (previousEnd !== end && typeof end === 'number') {
+        instance.setValue(end);
+      }
     }
     previousValue = value;
     previousStart = start;


### PR DESCRIPTION
Given the following example:

```
<script>
    import Slider from "@smui/slider";
	
    let start = 20;
    let end = 40;
</script>

<Slider
    range
    bind:start={start}
    bind:end={end}
    min={0}
    max={100}
    step={1}
    discrete
    tickMarks
    style="flex-grow: 1;"
    />
	
<div on:click={() => { start = 50; end = 70; }}>
    Click me
</div>
```

Clicking on `click me` crashes the component. What happens is that `previousEnd` is below `start`. The Material component expects `start` to always be smaller than `end`. But because the order of execution is always fixed (`start` first, `end` next), `start` becomes higher than `end`. This would have been fixed with the next call to `setValue`, but the Material component fails before it gets there.

With this change, it check what to do first: `start` or `end`, preventing this problem from happening.