### PR TITLE
PNPM support

### DIFF
--- a/packages/smui-theme/bin/index.js
+++ b/packages/smui-theme/bin/index.js
@@ -58,9 +58,17 @@ yargs(hideBin(process.argv))
           ...argv.includes,
           // Include the node_modules directory for MDC styles.
           path.resolve(
-            path.dirname(require.resolve('@material/dom/package.json')),
+            path.dirname(require.resolve('@material/theme/package.json')),
             '..',
             '..'
+          ),
+          // Hack to enable Sass lookup with PNPM.
+          path.resolve(
+            path.dirname(require.resolve('@material/theme/package.json')),
+            '..',
+            '..',
+            '.pnpm',
+            'node_modules'
           ),
           // Include the fallback directory, with no styles, for packages
           // that aren't installed

--- a/packages/smui-theme/package.json
+++ b/packages/smui-theme/package.json
@@ -30,6 +30,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@material/theme": "^13.0.0",
     "@smui-extra/accordion": "^6.0.0-beta.14",
     "@smui-extra/autocomplete": "^6.0.0-beta.14",
     "@smui-extra/badge": "^6.0.0-beta.14",


### PR DESCRIPTION
As parts of the SvelteKit ecosystem are moving towards PNPM as package manager (it uses symlinks a *lot* to be faster use less disk), supporting it become more pressing (https://github.com/hperrin/svelte-material-ui/issues/150, https://github.com/hperrin/svelte-material-ui/issues/348).

This PR makes following the instructions on https://sveltematerialui.com/THEMING.md work (when `npm`/`npx` are replaced with `pnpm`/`pnpx`, mutatis mutandis).

The core issue is that https://github.com/hperrin/svelte-material-ui/blob/9a2fa28a19242cf474c1b8b82f016e75575dd0ee/packages/smui-theme/bin/index.js#L61 uses `require.resolve` to determine the path to `./node_modules`
- using a package it does not depend on according to its `package.json`, and
- assuming the SASS files for all transitive dependencies will be located there in a flat structure

The first is a bug. I switched to (and added to `packages.json`) the dependency `@material/theme` instead of `@material/dom`, as this is what the file generated by `smui-theme template` directly depends on. I am not sure why `@material/dom` is currently there, and whether something else depends on it out of the box (this seems not to be the case, but I'm new to this repo).

The second is trickier, and I'm using a hacky solution inspired by https://github.com/hperrin/svelte-material-ui/issues/150 to solve it. It relies on the fact that while for PNPM the directory `./node_modules` contains only the direct dependencies, there is still inside `./node_modules/.pnpm` the versioned list of all indirect dependencies, and inside `./node_modules/.pnpm/node_modules` the unversioned list of all indirect dependencies (to the corresponding entries in its parent directory), making this directory a PNPM-equivalent (of `./node_modules` itself for NPM/Yarn) for Sass purposes.