### PR TITLE
feat: add an optional `confirm` prompt to Tab

### DIFF
--- a/packages/tab/src/Tab.svelte
+++ b/packages/tab/src/Tab.svelte
@@ -31,7 +31,7 @@
   aria-selected={active ? 'true' : 'false'}
   tabindex={active || forceAccessible ? '0' : '-1'}
   {href}
-  on:click={() => instance && instance.handleClick()}
+  on:click={handleClick}
   {...internalAttrs}
   {...exclude($$restProps, ['content$', 'tabIndicator$'])}
 >
@@ -66,10 +66,11 @@
 </svelte:component>
 
 <script lang="ts">
-  import type { TabIndicatorComponentDev } from '@smui/tab-indicator';
   import { MDCTabFoundation } from '@material/tab';
   import { onMount, setContext, getContext } from 'svelte';
-  import { get_current_component, SvelteComponentDev } from 'svelte/internal';
+  import type { SvelteComponentDev } from 'svelte/internal';
+  import { get_current_component } from 'svelte/internal';
+  import type { ActionArray } from '@smui/common/internal';
   import {
     forwardEventsBuilder,
     classMap,
@@ -77,13 +78,13 @@
     prefixFilter,
     useActions,
     dispatch,
-    ActionArray,
   } from '@smui/common/internal';
   import Ripple from '@smui/ripple';
   import { A, Button } from '@smui/common/elements';
+  import type { TabIndicatorComponentDev } from '@smui/tab-indicator';
   import TabIndicator from '@smui/tab-indicator';
 
-  import type { SMUITabAccessor } from './Tab.types.js';
+  import type { SMUITabAccessor } from './Tab.types';
 
   const forwardEvents = forwardEventsBuilder(get_current_component());
 
@@ -101,6 +102,7 @@
   export let href: string | undefined = undefined;
   export let content$use: ActionArray = [];
   export let content$class = '';
+  export let confirm: string | (() => boolean) | undefined = undefined;
 
   let element: SvelteComponentDev;
   let instance: MDCTabFoundation;
@@ -180,6 +182,20 @@
       instance.destroy();
     };
   });
+
+  function handleClick() {
+    let allowed;
+    if (typeof confirm === 'string') {
+      allowed = window.confirm(confirm);
+    } else if (confirm) {
+      allowed = confirm();
+    } else {
+      allowed = true;
+    }
+    if (allowed) {
+      instance?.handleClick();
+    }
+  }
 
   function hasClass(className: string) {
     return className in internalClasses


### PR DESCRIPTION
This lets you intercept and cancel the tab change.

What I needed it for was to show a confirm dialog "Are you sure you want to switch tabs without saving?" and let them cancel it to stay on the current tab.

Without this change, that is simply not possible. You could listen for `on:click` but by then the tab will have already changed (and unmounted my form with unsaved changes) and there's nothing you can do about it by that point.

I wasn't sure what to call this new prop. I chose `confirm` because it seems like the most likely use for it (you can even set it to a string and it will call `confirm()` for you), but I'd be happy to change it to something more neutral/generic if there is interest.

Other name ideas:
- `canChangeTab`
- `canLeaveTab`
- `canClick`
- `cancelClickIf`
- `confirmClick`
- `interceptClick`
- `disabled` (but that could seem to imply style differences)

## Ideally: just let the user call `event.preventDefault()`

Ideally (it would be cleaner since no new props need to be added), the user would just call [`event.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) from their `on:click` handler, and we would see `event.defaultPrevented` and cancel the click (not call `instance.handleClick()`). Is that possible?

I'll push up another PR attempt shortly if I get it working...

## Example

```js
...
    <TabBar tabs={validTabs} let:tab bind:active>
      <Tab {tab} confirm={confirmTabChange}>
        <Label>{tab}</Label>
      </Tab>
    </TabBar>
...

<script type="ts">
  function confirmTabChange() {
    if (!dirty) return true

    return confirm('Are you sure you want to switch tabs without saving? Unsaved changes will be lost.')
  }

</script>
```