### PR TITLE
feat: cancel tab click if event.defaultPrevented

### DIFF
--- a/packages/tab/src/Tab.svelte
+++ b/packages/tab/src/Tab.svelte
@@ -31,7 +31,7 @@
   aria-selected={active ? 'true' : 'false'}
   tabindex={active || forceAccessible ? '0' : '-1'}
   {href}
-  on:click={() => instance && instance.handleClick()}
+  on:click={handleClick}
   {...internalAttrs}
   {...exclude($$restProps, ['content$', 'tabIndicator$'])}
 >
@@ -66,10 +66,11 @@
 </svelte:component>
 
 <script lang="ts">
-  import type { TabIndicatorComponentDev } from '@smui/tab-indicator';
   import { MDCTabFoundation } from '@material/tab';
   import { onMount, setContext, getContext } from 'svelte';
-  import { get_current_component, SvelteComponentDev } from 'svelte/internal';
+  import type { SvelteComponentDev } from 'svelte/internal';
+  import { get_current_component } from 'svelte/internal';
+  import type { ActionArray } from '@smui/common/internal';
   import {
     forwardEventsBuilder,
     classMap,
@@ -77,13 +78,13 @@
     prefixFilter,
     useActions,
     dispatch,
-    ActionArray,
   } from '@smui/common/internal';
   import Ripple from '@smui/ripple';
   import { A, Button } from '@smui/common/elements';
+  import type { TabIndicatorComponentDev } from '@smui/tab-indicator';
   import TabIndicator from '@smui/tab-indicator';
 
-  import type { SMUITabAccessor } from './Tab.types.js';
+  import type { SMUITabAccessor } from './Tab.types';
 
   const forwardEvents = forwardEventsBuilder(get_current_component());
 
@@ -180,6 +181,12 @@
       instance.destroy();
     };
   });
+
+  function handleClick(event: PointerEvent) {
+    if (!event.defaultPrevented) {
+      instance?.handleClick();
+    }
+  }
 
   function hasClass(className: string) {
     return className in internalClasses


### PR DESCRIPTION
This lets you intercept and cancel the tab change. Without this change, that was not possible. `event.preventDefault()` had no effect.

This version supersedes #411 and seems like it would be preferred over adding a new prop.

## Example

What I needed this for was to show a confirm dialog "Are you sure you want to switch tabs without saving?" and let them cancel it to stay on the current tab.

```js
...
    <TabBar tabs={validTabs} let:tab bind:active>
      <Tab {tab} confirm={confirmTabChange}>
        <Label>{tab}</Label>
      </Tab>
    </TabBar>
...

<script type="ts">
  function handleTabClick(event) {
    if (!dirty) return

    if (
      !confirm('Are you sure you want to switch tabs without saving? Unsaved changes will be lost.')
    ) {
      event.preventDefault()
    }
  }
</script>
```

## Questions

This only works because the outer component's `on:click` handler seems to get triggered first _before_ Tab's `on:click` handler, which lets us check if the outer component's `on:click` handler has cancelled the event.

But is that order something we can guarantee and rely on?

Why do the handlers get called in this order? I assume it's because the `use:forwardEvents` `node.addEventListener` (`svelte/internal` `listen`) gets called _before_ the `node.addEventListener` for our local handler? Which thankfully causes it to forward the event before Tab's click handler.

Hopefully that can be relied upon, because it makes the implementation super simple, and I couldn't see any other way to make it work ...

## Also tried...

```js
  function handleClick(event: PointerEvent) {
    if (getElement().dispatchEvent(event)) {
```

But of course that doesn't work because:
```
Failed to execute 'dispatchEvent' on 'EventTarget': The event is already being dispatched.
```

Also tried to stop the original event and dispatch a new 'click' event ...

```js
  function handleClick(event: PointerEvent) {
    const newEvent = new PointerEvent('click', {
      ...event
    })
    console.log(event)
    event.preventDefault()
    if (getElement().dispatchEvent(newEvent)) {
      instance?.handleClick()
    }
```

... but that still results in infinite recursion.

Could also dispatch a custom event...

```js
  function handleClick(event: PointerEvent) {
    const newEvent = new CustomEvent('SMUI:click', {
      ...event
    })
    if (getElement().dispatchEvent(newEvent)) {
      instance?.handleClick()
```

or dispatching to an event target _above_ the one with our local `on:click` handler...

```svelte
<div bind:this={containerElement}>
  <svelte:component ...

  function handleClick(event: PointerEvent) {
    if (containerElement.dispatchEvent(event)) {
       instance?.handleClick()
    }
```

But why bother if the simple solution works :-)