### PR TITLE
Fix Class Adder Type Overlap tsc Error

### DIFF
--- a/packages/common/src/classadder/classAdderBuilder.ts
+++ b/packages/common/src/classadder/classAdderBuilder.ts
@@ -19,5 +19,5 @@ export function classAdderBuilder<T extends typeof SvelteComponentDev>(
       Object.assign(internals, defaults, props);
       return (target as any)[prop];
     },
-  }) as T;
+  }) as unknown as T;
 }


### PR DESCRIPTION
Hi @hperrin, hope you're well!

I wanted to re-submit #372 (original issue #415) as it was closed and I am not able to see why it was closed/who closed it.

This error is causing my `svelte-check` task to fail with the following error:

```
$ npm run check

> datagrid@0.0.1 check
> svelte-check --tsconfig ./tsconfig.json


====================================
Loading svelte-check in workspace: /Users/jcalabro/go/src/git.cogolo.net/jcalabro/datagrid.git/ui
Getting Svelte diagnostics...

/Users/jcalabro/go/src/git.cogolo.net/jcalabro/datagrid.git/ui/node_modules/@smui/common/src/classadder/classAdderBuilder.ts:12:10
Error: Conversion of type 'typeof ClassAdder__SvelteComponent_' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  'typeof ClassAdder__SvelteComponent_' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'typeof SvelteComponentDev'.
) {
  return new Proxy(ClassAdder, {
    construct: function (target, args) {
      Object.assign(internals, defaults, props);
      // @ts-ignore: Need spread arg.
      return new target(...args);
    },
    get: function (target, prop) {
      Object.assign(internals, defaults, props);
      return (target as any)[prop];
    },
  }) as T;
}
```

Casting `}) as unknown as T` will alleviate the error.

I believe I'm getting this because I'm using `"strict": true,` in my tsconfig.json.

Thank you! I've been enjoying using this library quite a bit!