### PR TITLE
fix: set accordion opened state based on open value

### DIFF
--- a/packages/accordion/src/Panel.svelte
+++ b/packages/accordion/src/Panel.svelte
@@ -94,7 +94,7 @@
               }
 
               // Assign only when the panel is fully opened.
-              opened = true;
+              opened = open;
 
               dispatch(getElement(), 'SMUIAccordionPanel:opened', { accessor });
             },


### PR DESCRIPTION
Using `true` in the `transitionend` event made it possible to close the panel before the transition ended, causing the `opened` variable to be set to `true`, which added the `smui-accordion__panel--opened` to the panel causing rendering issues.

Setting the value of `opened` with the current value of `open` at the end of the transition should reflect the state of `open` instead of the assumed `true`.

Another way this could have been implemented is through a check to open :

```ts
if (open) {
	opened = true;
}
```

But I decided to go simpler :)

Closes https://github.com/hperrin/svelte-material-ui/issues/427