### PR TITLE
feat: set title prop to value on textfield

### DIFF
--- a/packages/textfield/src/Input.svelte
+++ b/packages/textfield/src/Input.svelte
@@ -13,6 +13,7 @@
   {type}
   {placeholder}
   {...valueProp}
+  {...titleProp}
   {...internalAttrs}
   {...$$restProps}
 />
@@ -76,6 +77,15 @@
     valueProp = valueProp;
   } else {
     valueProp.value = value == null ? '' : value;
+  }
+
+  let titleProp: { title?: string | undefined } = {};
+
+  $: if (type === 'file') {
+    delete titleProp.title;
+    titleProp = titleProp;
+  } else {
+    titleProp.title = value == null ? '' : String(value);
   }
 
   onMount(() => {


### PR DESCRIPTION
Know the value of a textfield by hovering it. This is useful when the input is longer than the provided space:

![Screen Shot 2022-04-02 at 6 45 27 AM](https://user-images.githubusercontent.com/127199/161386590-8535c17e-f0c9-486d-adaf-3dbe9b36dd82.png)