### PR TITLE
feat: Added strong typing for TabBar component

### DIFF
--- a/packages/tab-bar/src/TabBar.svelte
+++ b/packages/tab-bar/src/TabBar.svelte
@@ -41,27 +41,29 @@
   import type { TabScrollerComponentDev } from '@smui/tab-scroller';
   import TabScroller from '@smui/tab-scroller';
 
+  type PrimitiveKey = string | number;
+  type TabKey = $$Generic<Object | PrimitiveKey>;
+  interface $$Slots {
+    default: { tab: TabKey };
+  }
   const forwardEvents = forwardEventsBuilder(get_current_component());
 
   // Remember to update types file if you add/remove/rename props.
   export let use: ActionArray = [];
   let className = '';
   export { className as class };
-  export let tabs: any[] = [];
-  export let key: (tab: any) => string | number = (tab) => tab;
+  export let tabs: TabKey[] = [];
+  export let key: (tab: TabKey) => PrimitiveKey = (tab) => tab as PrimitiveKey;
   export let focusOnActivate = true;
   export let focusOnProgrammatic = false;
   export let useAutomaticActivation = true;
-  export let active: any | undefined = undefined;
+  export let active: TabKey | undefined = undefined;
 
   let element: HTMLDivElement;
   let instance: MDCTabBarFoundation;
   let tabScroller: TabScrollerComponentDev;
-  let activeIndex = tabs.indexOf(active);
-  let tabAccessorMap: {
-    [k: string]: SMUITabAccessor;
-    [k: number]: SMUITabAccessor;
-  } = {};
+  let activeIndex = tabs.indexOf(active!);
+  let tabAccessorMap: Record<PrimitiveKey, SMUITabAccessor> = {};
   let tabAccessorWeakMap = new WeakMap<Object, SMUITabAccessor>();
   let skipFocus = false;
 
@@ -69,7 +71,7 @@
   setContext('SMUI:tab:initialActive', active);
 
   $: if (active !== tabs[activeIndex]) {
-    activeIndex = tabs.indexOf(active);
+    activeIndex = tabs.indexOf(active!);
     if (instance) {
       skipFocus = !focusOnProgrammatic;
       instance.activateTab(activeIndex);
@@ -82,7 +84,7 @@
     const accessor =
       tabs[0] instanceof Object
         ? tabAccessorWeakMap.get(tabs[0])
-        : tabAccessorMap[tabs[0]];
+        : tabAccessorMap[tabs[0] as PrimitiveKey];
 
     if (accessor) {
       accessor.forceAccessible(activeIndex === -1);
@@ -134,7 +136,7 @@
         const activeElement = document.activeElement;
         return tabElements.indexOf(activeElement as HTMLElement);
       },
-      getIndexOfTabById: (id) => tabs.indexOf(id),
+      getIndexOfTabById: (id) => tabs.indexOf(id as TabKey),
       getTabListLength: () => tabs.length,
       notifyTabActivated: (index) =>
         dispatch(

--- a/packages/tab-bar/src/TabBar.types.ts
+++ b/packages/tab-bar/src/TabBar.types.ts
@@ -1,7 +1,7 @@
 import type { TabScrollerComponentDev } from '@smui/tab-scroller';
 import type Component from './TabBar.svelte';
 
-export declare class TabBarComponentDev extends Component {
+export declare class TabBarComponentDev<T> extends Component<T> {
   /**
    * @private
    * For type checking capabilities only.
@@ -22,5 +22,5 @@ export declare class TabBarComponentDev extends Component {
     {
       [k in keyof TabScrollerComponentDev['$$prop_def'] as `tabScroller\$${k}`]?: TabScrollerComponentDev['$$prop_def'][k];
     } &
-    Component['$$prop_def'];
+    Component<T>['$$prop_def'];
 }


### PR DESCRIPTION
I've added generic definition for the tab declaration elements. (see [Svelte Generics](https://github.com/dummdidumm/rfcs/blob/ts-typedefs-within-svelte-components/text/ts-typing-props-slots-events.md))

This makes the development experice a bit nicer since it warns you when for eg. `tabs` and `active` are not the same type.
![grafik](https://user-images.githubusercontent.com/6502527/162737160-3783e9f3-a74d-446b-a37a-c7abcbcc6ae2.png)
Also the nested `tab` property gives you intellisense when accessing object properties.
![grafik](https://user-images.githubusercontent.com/6502527/162736178-cbeca857-1d0f-4b2c-b369-1c510edc7ab5.png)

**Note**: this *might* be a typechecking breaking change. But this should only happen if the code before wasn't type-correct already but suppessed by the `any` type of the `tab` variable.

Let me know if there's anything you don't like, I should change, or are generally not interested in this feature.