### PR TITLE
fix: resolved "max height" typo in menu-surface

### DIFF
--- a/packages/menu-surface/src/MenuSurface.svelte
+++ b/packages/menu-surface/src/MenuSurface.svelte
@@ -220,7 +220,7 @@
           'bottom' in position ? `${position.bottom}px` : '';
       },
       setMaxHeight: (height) => {
-        internalStyles.maxHeight = height;
+        internalStyles["max-height"] = height;
       },
     });
 


### PR DESCRIPTION
Change `internalStyles.maxHeight` to `internalStyles["max-height"]` in order to change the max height. Former behavior did not function.

Closes #223