### PR TITLE
Allow banners to have no action buttons

### DIFF
--- a/packages/banner/src/Banner.svelte
+++ b/packages/banner/src/Banner.svelte
@@ -134,9 +134,10 @@
   }
 
   onMount(() => {
-    focusTrap = new FocusTrap(element, {
-      initialFocusEl: getPrimaryActionEl(),
-    });
+    let initialFocusEl = getPrimaryActionEl();
+    if (initialFocusEl) {
+      focusTrap = new FocusTrap(element, { initialFocusEl });
+    }
 
     instance = new MDCBannerFoundation({
       addClass,


### PR DESCRIPTION
Without that, the FocusTrap complains it has no focusable child (which it won't have if the user decides to not include the "actions" slot).