### PR TITLE
Add `bare.css` export to snackbar package

### DIFF
--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -7,6 +7,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": "./dist/index.js",
+    "./bare.css": "./bare.css",
     "./kitchen": "./dist/kitchen/index.js"
   },
   "typesVersions": {


### PR DESCRIPTION
As it stands bare.css is not exported from the snackbar package. You have to manually change this file after every yarn/yarn add. Please get this released ASAP