### PR TITLE
Explicitly return undefined when event is undefined

### DIFF
--- a/packages/common/src/internal/dispatch.ts
+++ b/packages/common/src/internal/dispatch.ts
@@ -27,4 +27,5 @@ export function dispatch<T extends any = any>(
     }
     return event;
   }
+  return undefined;
 }


### PR DESCRIPTION
Fixes #514