### PR TITLE
Fix `NaN` in `toNumber`

### DIFF
--- a/packages/textfield/src/Input.svelte
+++ b/packages/textfield/src/Input.svelte
@@ -104,9 +104,7 @@
 
   function toNumber(value: string) {
     if (value === '') {
-      const nan = new Number(Number.NaN);
-      (nan as unknown as Array<any>).length = 0;
-      return nan as number;
+      return NaN;
     }
     return +value;
   }


### PR DESCRIPTION
i'm not sure why it was creating a `new Number` and setting a `length` property on it. my understanding is that the primitive wrapper objects (`Number`, `String`, etc.) should be avoided.

in my case it was causing problems in my code because i was using `typeof value === 'number'` to check if a value was a number, when it was actually an `'object'`