### PR TITLE
fix: erroneous import of HttpsProxyAgent

### DIFF
--- a/packages/smui-theme/bin/index.js
+++ b/packages/smui-theme/bin/index.js
@@ -4,7 +4,7 @@ const sass = require('sass');
 const fetch = require('node-fetch');
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
-const HttpsProxyAgent = require('https-proxy-agent');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 
 yargs(hideBin(process.argv))
   .command(


### PR DESCRIPTION
According to the guide, running `npx smui-theme template src/theme` is a setup step for this package. However, I encountered the error `TypeError: HttpsProxyAgent is not a constructor` during the setup. Changing how this constructor is imported fixed the problem. I'm not aware of recent changes in the API of this `HttpsProxyAgent `, but I had to make this change in my local copy of the library. Maybe you can go through some more thorough testing.