### PR TITLE
feat: add maxOptionsToDisplay option to improve autocomplete performance on long lists

### DIFF
--- a/packages/autocomplete/src/Autocomplete.svelte
+++ b/packages/autocomplete/src/Autocomplete.svelte
@@ -63,7 +63,7 @@
           </slot>
         </Item>
       {:else}
-        {#each matches as match, i}
+        {#each matchesToDisplay as match, i}
           <Item
             disabled={getOptionDisabled(match)}
             selected={match === value}
@@ -193,6 +193,7 @@
     });
     return result;
   };
+  export let maxOptionsToDisplay = 0;
   export let menu$class = '';
   export let menu$anchor = false;
   export let menu$anchorCorner: ComponentProps<Menu>['anchorCorner'] =
@@ -205,6 +206,8 @@
   let focused = false;
   let listAccessor: SMUIListAccessor;
   let matches: any[] = [];
+  $: matchesToDisplay =
+    maxOptionsToDisplay > 0 ? matches.slice(0, maxOptionsToDisplay) : matches;
   let focusedIndex = -1;
   let focusedItem: SMUIListItemAccessor | undefined = undefined;
 

--- a/packages/site/src/routes/demo/autocomplete/+page.svelte
+++ b/packages/site/src/routes/demo/autocomplete/+page.svelte
@@ -9,6 +9,16 @@
 
   <pre class="demo-spaced">npm i -D @smui-extra/autocomplete</pre>
 
+  <h5>Performance</h5>
+
+  <p>
+    When dealing with long lists (&gt;50 elements), the creation of the DOM
+    elements inside the list starts to become a bottleneck. In this case, you
+    may want to use the <code>maxOptionsToDisplay</code> option. This option limits
+    the number of list items that can be rendered at a time. When set to 0 (default),
+    every item will be rendered.
+  </p>
+
   <h5>Demos</h5>
 
   <Demo component={Simple} file="autocomplete/_Simple.svelte" />


### PR DESCRIPTION
When using autocomplete with lists > 50ish in length, the creation of Svelte/DOM components in the list starts to become a performance bottleneck. It starts to become slow enough for an annoying user experience past 100. Since SMUI doesn't have any sort of virtual list component that I know of, simply limiting the number of rendered results is what I believe is a simple yet effective solution to the problem. In cases where you have a really long list but MUST render them all, then they can just keep the default value and let all the list items render.