### PR TITLE
fix: prettier format extremely slow because autogenerated css not excluded

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,7 +7,5 @@ dist
 /.github
 /lerna.json
 /packages/site/build
-/packages/site/static/smui.css
-/packages/site/static/smui-dark.css
-/packages/site/static/site.css
-/packages/site/static/site-dark.css
+/packages/site/static/*.css
+/packages/svelte-material-ui/themes


### PR DESCRIPTION
Since `npm run format` is **mandatory** before git lets you make a commit, it shouldn't take long to run. The `.prettierignore` file is out of date, leading to the auto-generated css files inside `packages/site/static` and `/packages/svelte-material-ui/themes` being included in the format list. And since the css files are very large, it takes a very long time for each file, leading to an infuriating wait time before the linting completes and you're finally allowed to commit a change.