### PR TITLE
add exports svelte rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11393,9 +11393,9 @@
       "link": true
     },
     "node_modules/svelte-portal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
-      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.1.tgz",
+      "integrity": "sha512-uF7is5sM4aq5iN7QF/67XLnTUvQCf2iiG/B1BHTqLwYVY1dsVmTeXZ/LeEyU6dLjApOQdbEG9lkqHzxiQtOLEQ==",
       "dev": true
     },
     "node_modules/svelte-preprocess": {
@@ -13059,7 +13059,7 @@
         "smui-theme": "^7.0.0-beta.16",
         "svelte": "^4.2.8",
         "svelte-check": "^3.6.2",
-        "svelte-portal": "^2.2.0",
+        "svelte-portal": "^2.2.1",
         "svelte-preprocess": "^5.1.3",
         "tinygesture": "^3.0.0",
         "tslib": "^2.6.2",
@@ -16258,7 +16258,7 @@
         "smui-theme": "^7.0.0-beta.16",
         "svelte": "^4.2.8",
         "svelte-check": "^3.6.2",
-        "svelte-portal": "^2.2.0",
+        "svelte-portal": "^2.2.1",
         "svelte-preprocess": "^5.1.3",
         "tinygesture": "^3.0.0",
         "tslib": "^2.6.2",
@@ -23569,9 +23569,9 @@
       }
     },
     "svelte-portal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
-      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.1.tgz",
+      "integrity": "sha512-uF7is5sM4aq5iN7QF/67XLnTUvQCf2iiG/B1BHTqLwYVY1dsVmTeXZ/LeEyU6dLjApOQdbEG9lkqHzxiQtOLEQ==",
       "dev": true
     },
     "svelte-preprocess": {

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/bottom-app-bar/package.json
+++ b/packages/bottom-app-bar/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/chips/package.json
+++ b/packages/chips/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/circular-progress/package.json
+++ b/packages/circular-progress/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/floating-label/package.json
+++ b/packages/floating-label/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/form-field/package.json
+++ b/packages/form-field/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/image-list/package.json
+++ b/packages/image-list/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/layout-grid/package.json
+++ b/packages/layout-grid/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/line-ripple/package.json
+++ b/packages/line-ripple/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/menu-surface/package.json
+++ b/packages/menu-surface/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/menu/src/SelectionGroupIcon.ts
+++ b/packages/menu/src/SelectionGroupIcon.ts
@@ -5,5 +5,5 @@ import { Graphic } from '@smui/list';
 
 export default classAdderBuilder<keyof SmuiElementMap, typeof SvelteComponent>({
   class: 'mdc-menu__selection-group-icon',
-  component: Graphic as typeof SvelteComponent,
+  component: Graphic as unknown as typeof SvelteComponent,
 });

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "dist/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/segmented-button/package.json
+++ b/packages/segmented-button/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -125,7 +125,7 @@
     "smui-theme": "^7.0.0-beta.16",
     "svelte": "^4.2.8",
     "svelte-check": "^3.6.2",
-    "svelte-portal": "^2.2.0",
+    "svelte-portal": "^2.2.1",
     "svelte-preprocess": "^5.1.3",
     "tinygesture": "^3.0.0",
     "tslib": "^2.6.2",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",

--- a/packages/touch-target/package.json
+++ b/packages/touch-target/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "src/index.d.ts",
   "keywords": [
     "svelte",


### PR DESCRIPTION
Shall fix #644.

Notes:
- I have not checked for internal parts that also might need explicit export rules, thus this might not be sufficient. It is at least enough to get `npm run build` and the site demo working.
- There was an ugly type patch needed in `menu/src/SelectionGroupIcon.ts`, this should be revised by someone with more knowledge of the inner works.