### PR TITLE
docs: remove useless counter in simple card demo

### DIFF
--- a/packages/site/src/routes/demo/card/_Simple.svelte
+++ b/packages/site/src/routes/demo/card/_Simple.svelte
@@ -14,10 +14,6 @@
   </div>
 </div>
 
-<pre class="status">Clicked: {clicked}</pre>
-
 <script lang="ts">
   import Card, { Content } from '@smui/card';
-
-  let clicked = 0;
 </script>


### PR DESCRIPTION
Remove a useless counter in simple card demo since it is never used.
![image](https://github.com/hperrin/svelte-material-ui/assets/73600915/2caf9944-de9a-4f7f-bb03-c27451387275)
