### PR TITLE
fix TypeError: HttpsProxyAgent is not a constructor

### DIFF
--- a/packages/smui-theme/bin/index.js
+++ b/packages/smui-theme/bin/index.js
@@ -117,7 +117,7 @@ yargs(hideBin(process.argv))
           }_smui-theme.scss`,
           {
             agent: process.env['https_proxy']
-              ? new HttpsProxyAgent(process.env['https_proxy'])
+              ? new HttpsProxyAgent.HttpsProxyAgent(process.env['https_proxy'])
               : undefined,
           },
         ).then((result) => result.text());


### PR DESCRIPTION
another example of this issue after searching: https://github.com/websockets/wscat/issues/156