### PR TITLE
Change type of type to HTMLInputTypeAttribute

### DIFF
--- a/packages/textfield/src/Textfield.svelte
+++ b/packages/textfield/src/Textfield.svelte
@@ -250,6 +250,7 @@
   import { MDCTextFieldFoundation } from '@material/textfield';
   import { events } from '@material/dom';
   import type { ComponentProps, Snippet } from 'svelte';
+  import type { HTMLInputTypeAttribute } from 'svelte/elements';
   import { onMount, onDestroy, getContext, setContext, tick } from 'svelte';
   import type {
     AddLayoutListener,
@@ -330,7 +331,7 @@
     /**
      * The input type.
      */
-    type?: string;
+    type?: HTMLInputTypeAttribute;
     /**
      * The value of the input.
      */


### PR DESCRIPTION
Hi,

we are currently using `svelte-material-ui` for a project.

With this PR we propose to change the type of the `type` of the `Textfield` component so it matches the `svelte/elements` definition.

Does this make sense to you?