### PR TITLE
fix: Made ordering of classes always havee custom classes at end on c…

### DIFF
--- a/packages/card/src/Card.svelte
+++ b/packages/card/src/Card.svelte
@@ -4,10 +4,10 @@
   bind:this={element}
   use:useActions={use}
   class={classMap({
-    [className]: true,
     'mdc-card': true,
     'mdc-card--outlined': variant === 'outlined',
     'smui-card--padded': padded,
+    [className]: true,
   })}
   {...restProps}
 >


### PR DESCRIPTION
Fixes #698 

This PR moves the definition of className to the end of the classMap for the card component. This is important as it allows the user to override styling on the card.

I'm unsure if this is an issue for other components as well, but if it is, I HIGHLY recommend making the same change to the other components. As it stands without this you are completely unable to use the provided elevation on card components. If this is the case for other components as well then this is very unfortunate